### PR TITLE
Adding Gulp watch documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ import rollupStream from '@rollup/stream';
 import buffer from 'vinyl-buffer';
 import gulp from 'gulp';
 import sourcemaps from 'gulp-sourcemaps';
-import terser from 'gulp-terser';
 import source from 'vinyl-source-stream';
 
 gulp.task('rollup', () => {
@@ -100,7 +99,49 @@ gulp.task('rollup', () => {
 });
 ```
 
-_(Example reproduced from https://github.com/Permutatrix/rollup-stream#readme)_
+### Watching for changes
+
+To optimize build times, you will need to make use of the `cache` option when watching for file changes:
+
+```js
+import rollupStream from '@rollup/stream';
+import buffer from 'vinyl-buffer';
+import gulp from 'gulp';
+import source from 'vinyl-source-stream';
+
+// cache variable needs to be stored outside the gulp task
+let cache;
+
+gulp.task('rollup', () => {
+  const options = {
+    input: 'src/index.js',
+    // Apply cache in the options object
+    cache: cache,
+  };
+  return rollupStream(options)
+    .on('bundle', bundle => {
+      // Update the cache data after every new bundle is created
+      cache = bundle;
+    })
+    .pipe(source('bundle.js'))
+    .pipe(buffer())
+    .pipe(gulp.dest('dist'));
+});
+
+gulp.task('watch', done => {
+
+  // Gulp 4
+  gulp.watch('./src/**/*.js', gulp.series('rollup'));
+
+  // Gulp 3
+  gulp.watch('./src/**/*.js', ['rollup']);
+
+  done();
+});
+
+```
+
+_(Example reproduced from [Rollup-Stream readme](https://github.com/Permutatrix/rollup-stream#readme))_
 
 ## Options
 


### PR DESCRIPTION
<!--
  ⚡️ katchow! We ❤️ Pull Requests!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Pull Request Requirements:
  * Please include tests to illustrate the problem this PR resolves.
  * Please lint your changes by running `npm run lint` before creating a PR.
  * Please update the documentation in `/docs` where necessary

  Please place an x (no spaces - [x]) in all [ ] that apply.
-->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [x] documentation
- [ ] other

Are tests included?

- [ ] yes (_bugfixes and features will not be merged without tests_)
- [x] no

Breaking Changes?

- [ ] yes (_breaking changes will not be merged unless absolutely necessary_)
- [x] no

List any relevant issue numbers: https://github.com/rollup/stream/issues/1

### Description

This pull request adds documentation to guide users on how to most effectively use `@rollup/stream` in a Gulp watch task.

I also removed `import terser from 'gulp-terser';` from the source-maps example since it wasn't being used in the example and it might confuse people.

I also converted the rollup-stream readme link to a cleaner text based link rather than a url.

<!--
  Please be thorough and clearly explain the problem being solved.
  * If this PR adds a feature, look for previous discussion on the feature by searching the issues first.
  * Is this PR related to an issue?
-->
